### PR TITLE
Fix /tools/style-info to return LaymanError for non-parsable XML files

### DIFF
--- a/src/layman/layer/filesystem/input_style.py
+++ b/src/layman/layer/filesystem/input_style.py
@@ -139,7 +139,10 @@ def get_style_type_from_file_storage(file_storage):
     if file_storage:
         xml = file_storage.read()
         file_storage.seek(0)
-        xml_tree = etree.fromstring(xml)
+        try:
+            xml_tree = etree.fromstring(xml)
+        except etree.XMLSyntaxError as exc:
+            raise LaymanError(46) from exc
         root_tag = xml_tree.tag
         root_attribute = etree.QName(root_tag).localname
         result = next((sd for sd in layer.STYLE_TYPES_DEF if sd.root_element == root_attribute), None)

--- a/src/layman/layer/filesystem/input_style_test.py
+++ b/src/layman/layer/filesystem/input_style_test.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from contextlib import nullcontext as does_not_raise
-import lxml
 import pytest
 from werkzeug.datastructures import FileStorage
 
@@ -29,7 +28,7 @@ def test_get_style_type_from_xml_file(file_path,
 
 @pytest.mark.parametrize('file_path, expected_error, expected_code', [
     ('sample/style/no_style.xml', LaymanError, 46),
-    ('sample/style/countries_wms_blue.png', lxml.etree.XMLSyntaxError, 4),
+    ('sample/style/countries_wms_blue.png', LaymanError, 46),
 ])
 def test_get_style_type_from_xml_file_errors(file_path,
                                              expected_error,

--- a/tests/immutable_endpoints/rest_tools_test.py
+++ b/tests/immutable_endpoints/rest_tools_test.py
@@ -25,6 +25,12 @@ def test_post_style_info(style_file, expected_json):
       'detail': {'parameter': 'style', },
       },
      ),
+    ({'style_file': 'test_tools/data/thumbnail/layer_square_external_svg.png'},
+     {'http_code': 400,
+      'code': 46,
+      'message': 'Unknown style file. Can recognize only SLD and QML files.',
+      },
+     ),
 ])
 @pytest.mark.usefixtures('ensure_layman')
 def test_post_style_info_error(params, expected_exc):


### PR DESCRIPTION
Part of issue #258

- [x] Tests
- ~~Layman Test Client~~
- ~~Changlelog~~
- ~~Documentation~~

Optionally
- Add dependency to doc/dependencies.md
