### PR TITLE
Stop importing layman_settings dynamically

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -5,9 +5,6 @@
 # dir where uploaded files are stored
 LAYMAN_DATA_DIR=/layman_data
 
-# name of python module with layman settings
-LAYMAN_SETTINGS_MODULE=layman_settings
-
 # general connection parameters
 DEFAULT_CONNECTION_TIMEOUT=10
 

--- a/.env.dev
+++ b/.env.dev
@@ -5,9 +5,6 @@
 # dir where uploaded files are stored
 LAYMAN_DATA_DIR=/layman_data
 
-# name of python module with layman settings
-LAYMAN_SETTINGS_MODULE=layman_settings
-
 # general connection parameters
 DEFAULT_CONNECTION_TIMEOUT=5
 

--- a/.env.test
+++ b/.env.test
@@ -5,9 +5,6 @@
 # dir where uploaded files are stored
 LAYMAN_DATA_DIR=/layman_data_test
 
-# name of python module with layman settings
-LAYMAN_SETTINGS_MODULE=layman_settings
-
 # general connection parameters
 DEFAULT_CONNECTION_TIMEOUT=5
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@
 **/.pytest_cache
 /venv
 
-src/layman_settings.py
-
 /deps/*/data
 /deps/*/tmp
 /deps/*/log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.16.0
  {release_date}
 ### Upgrade requirements
+- Unset environment variable [LAYMAN_SETTINGS_MODULE](https://github.com/LayerManager/layman/blob/v1.15.0/doc/env-settings.md), it has no effect anymore.
 ### Migrations and checks
 #### Schema migrations
 - [#64](https://github.com/LayerManager/layman/issues/64) Create new column `srid` in `publication` table.
@@ -12,6 +13,7 @@
    - `native_crs` with code of native CRS in form "EPSG:&lt;code&gt;", e.g. "EPSG:4326"
    - `native_bounding_box` with coordinates and CRS of native CRS  [minx, miny, maxx, maxy, "EPSG:&lt;code&gt;"]
 - [#489](https://github.com/LayerManager/layman/issues/489) Error responses from Micka and GeoServer are logged into log and also propagated as part of raised exception, so they can be seen from flower.
+- Remove [LAYMAN_SETTINGS_MODULE](https://github.com/LayerManager/layman/blob/v1.15.0/doc/env-settings.md), import [`src/layman_settings.py`](src/layman_settings.py) directly.
 
 ## v1.15.0
  2021-11-18
@@ -400,7 +402,7 @@ There is a critical bug in this release, posting new layer breaks Layman: https:
 ## v1.6.0
 2020-08-19
 ### Upgrade requirements
-- [#69](https://github.com/LayerManager/layman/issues/69) If you are running Layman with development or test settings, set [LAYMAN_SETTINGS_MODULE](doc/env-settings.md#LAYMAN_SETTINGS_MODULE) in your `.env` file to `layman_settings`. No action is required if you are running Layman based on demo settings (probably all production instances).
+- [#69](https://github.com/LayerManager/layman/issues/69) If you are running Layman with development or test settings, set [LAYMAN_SETTINGS_MODULE](https://github.com/LayerManager/layman/blob/v1.6.0/doc/env-settings.md) in your `.env` file to `layman_settings`. No action is required if you are running Layman based on demo settings (probably all production instances).
 ### Changes
 - [#74](https://github.com/LayerManager/layman/issues/74) Layman user and role at GeoServer defined by [LAYMAN_GS_USER](doc/env-settings.md#LAYMAN_GS_USER) and [LAYMAN_GS_ROLE](doc/env-settings.md#LAYMAN_GS_ROLE) are now created automatically on Layman's startup if an only if new environment variable [GEOSERVER_ADMIN_PASSWORD](doc/env-settings.md#GEOSERVER_ADMIN_PASSWORD) is provided. There is no need to set [GEOSERVER_ADMIN_PASSWORD](doc/env-settings.md#GEOSERVER_ADMIN_PASSWORD) for other reason than automatically creating Layman user and Layman role.
    - No change is required. If you are migrating existing instance, Layman user and role are already created, so you don't need to set [GEOSERVER_ADMIN_PASSWORD](doc/env-settings.md#GEOSERVER_ADMIN_PASSWORD). If this is your first Layman release, [GEOSERVER_ADMIN_PASSWORD](doc/env-settings.md#GEOSERVER_ADMIN_PASSWORD) is set in `.env` files starting with this version, so Layman user and role at GeoServer will be automatically created on startup.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Layman's source code provides settings suitable for development, testing and dem
 Layman's configuration is split into three levels:
 - `docker-compose.*.yml` files used as [docker-compose configuration files](https://docs.docker.com/compose/compose-file/) with most general settings of docker containers including volume mappings, port mappings, container names and startup commands
 - `.env*` files with environment settings of both build stage and runtime of docker containers
-- `src/layman_settings*.py` Python modules with settings of Layman's Python modules for runtime
+- `src/layman_settings.py` Python module with settings of Layman's Python modules for runtime
 
 Files at all three levels are suffixed with strings that indicates what they are intended to:
 - `demo` to [demonstration purposes](#run-demo)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ Npm is recommended tool for installing **node.js-level** dependencies. Both pack
 Next you need to choose how you deploy Layman. As Layman is Flask application, check Flask's [deployment options](https://flask.palletsprojects.com/en/1.1.x/deploying/). Layman is safe to run with multiple WSGI Flask processes and with multiple Celery worker processes.
 
 Configure Layman using [environment settings](doc/env-settings.md). Demo configuration is a good starting point to setup Layman for production, however it needs to be adjusted carefully. First focus for example on
-- [LAYMAN_SETTINGS_MODULE](doc/env-settings.md#LAYMAN_SETTINGS_MODULE)
 - [FLASK_APP](doc/env-settings.md#FLASK_APP)
 - [FLASK_ENV](doc/env-settings.md#FLASK_ENV) (should be set to `production`)
 - [FLASK_SECRET_KEY](doc/env-settings.md#FLASK_SECRET_KEY)

--- a/doc/env-settings.md
+++ b/doc/env-settings.md
@@ -2,9 +2,6 @@
 
 ## General Layman settings
 
-### LAYMAN_SETTINGS_MODULE
-Dotted path to a Python module with Layman settings for Python level.
-
 ### LAYMAN_DATA_DIR
 Filesystem directory where most of published data is stored, including data about authentication credentials, users, and publications.
 
@@ -203,7 +200,7 @@ Internal URL of [OGC Catalogue Service v2.0.2](https://www.opengeospatial.org/st
 Public URL of [OGC Catalogue Service v2.0.2](https://www.opengeospatial.org/standards/cat) endpoint. Tested with [Micka](http://micka.bnhelp.cz/).
 
 ### MICKA_ACCEPTED_VERSION
-Version of Micka that Layman will accept on startup encoded as `version:revision`, e.g. `2020.014:2020-04-15.01`. Also, on one of '>=' or '==' prefixes can be used with obvious meaning, `e.g. >=2020.014:2020-04-15.01`. For prefix '>=', version and revision are compared independently as strings. If the variable is not set, a version defined in [LAYMAN_SETTINGS_MODULE](#LAYMAN_SETTINGS_MODULE) will be accepted. If none prefix is used, value is compared as with '=='.
+Version of Micka that Layman will accept on startup encoded as `version:revision`, e.g. `2020.014:2020-04-15.01`. Also, on one of '>=' or '==' prefixes can be used with obvious meaning, `e.g. >=2020.014:2020-04-15.01`. For prefix '>=', version and revision are compared independently as strings. If the variable is not set, a version defined in [`src/layman_settings.py`](../src/layman_settings.py) will be accepted. If none prefix is used, value is compared as with '=='.
 
 ### MICKA_HOSTPORT
 String with public domain and optionally port, e.g. `<domain>` or `<domain>:<port>`. Passed as configuration to Micka for demo purposes.

--- a/src/assert_db.py
+++ b/src/assert_db.py
@@ -1,9 +1,7 @@
-import importlib
-import os
 import sys
 import time
+import layman_settings as settings
 
-settings = importlib.import_module(os.environ['LAYMAN_SETTINGS_MODULE'])
 
 ATTEMPT_INTERVAL = 1
 MAX_ATTEMPTS = 10

--- a/src/clear_layman_data.py
+++ b/src/clear_layman_data.py
@@ -1,11 +1,8 @@
-import importlib
 import os
 import shutil
 from urllib.parse import urljoin
-
 import geoserver
-
-settings = importlib.import_module(os.environ['LAYMAN_SETTINGS_MODULE'])
+import layman_settings as settings
 
 
 def clear_directory(directory):

--- a/src/layman/__init__.py
+++ b/src/layman/__init__.py
@@ -1,11 +1,12 @@
 import os
-import importlib
 import sys
 import time
 from flask import Flask, redirect, jsonify
 from flask.logging import create_logger
 
 from redis import WatchError
+
+import layman_settings as settings
 
 IN_CELERY_WORKER_PROCESS = sys.argv and sys.argv[0].endswith('/celery/__main__.py')
 IN_PYTEST_PROCESS = sys.argv and sys.argv[0].endswith('/pytest/__main__.py')
@@ -21,8 +22,6 @@ assert [
     IN_UPGRADE_PROCESS,
     IN_UTIL_PROCESS,
 ].count(True) == 1, f"IN_CELERY_WORKER_PROCESS={IN_CELERY_WORKER_PROCESS}, IN_PYTEST_PROCESS={IN_PYTEST_PROCESS}, IN_FLOWER_PROCESS={IN_FLOWER_PROCESS}, IN_FLASK_PROCESS={IN_FLASK_PROCESS}, IN_UPGRADE_PROCESS={IN_UPGRADE_PROCESS}, IN_UTIL_PROCESS={IN_UTIL_PROCESS}, sys.argv={sys.argv}"
-
-settings = importlib.import_module(os.environ['LAYMAN_SETTINGS_MODULE'])
 
 app = Flask(__name__)
 app.secret_key = os.environ['FLASK_SECRET_KEY']

--- a/src/layman/upgrade/upgrade_v1_8.py
+++ b/src/layman/upgrade/upgrade_v1_8.py
@@ -2,6 +2,7 @@ from urllib.parse import urljoin
 import logging
 import requests
 
+import geoserver
 from geoserver import util as gs_util
 from layman import app, settings
 from layman.common import geoserver as gs_common
@@ -41,7 +42,7 @@ def upgrade_1_8():
 
             for type in ['w', 'r']:
                 response = requests.delete(
-                    urljoin(settings.LAYMAN_GS_REST_SECURITY_ACL_LAYERS, username + '.*.' + type),
+                    urljoin(geoserver.GS_REST_SECURITY_ACL_LAYERS, username + '.*.' + type),
                     headers=headers_json,
                     auth=settings.LAYMAN_GS_AUTH
                 )

--- a/src/layman_flush_redis.py
+++ b/src/layman_flush_redis.py
@@ -1,8 +1,6 @@
-import importlib
 import os
+import layman_settings as settings
 
-
-settings = importlib.import_module(os.environ['LAYMAN_SETTINGS_MODULE'])
 
 ATTEMPT_INTERVAL = 2
 MAX_ATTEMPTS = 60

--- a/src/setup_geoserver.py
+++ b/src/setup_geoserver.py
@@ -1,13 +1,10 @@
-import importlib
 import logging
-import os
 import sys
 
 import geoserver
 from geoserver import epsg_properties
 from geoserver import authn
-
-settings = importlib.import_module(os.environ['LAYMAN_SETTINGS_MODULE'])
+import layman_settings as settings
 
 
 logger = logging.getLogger(__name__)

--- a/src/wait_for_deps.py
+++ b/src/wait_for_deps.py
@@ -1,13 +1,11 @@
-import importlib
-import os
 import re
 import sys
 import time
 from urllib.parse import urljoin
 
 import geoserver
+import layman_settings as settings
 
-settings = importlib.import_module(os.environ['LAYMAN_SETTINGS_MODULE'])
 
 ATTEMPT_INTERVAL = 2
 MAX_ATTEMPTS = 60

--- a/test_tools/mock/liferay/app.py
+++ b/test_tools/mock/liferay/app.py
@@ -1,8 +1,5 @@
-import os
-import importlib
 from flask import Flask, request, jsonify, Blueprint, current_app
 
-settings = importlib.import_module(os.environ['LAYMAN_SETTINGS_MODULE'])
 
 TOKEN_HEADER = 'Authorization'
 

--- a/test_tools/mock/micka/app.py
+++ b/test_tools/mock/micka/app.py
@@ -1,8 +1,5 @@
 import os
-import importlib
 from flask import Flask, Blueprint
-
-settings = importlib.import_module(os.environ['LAYMAN_SETTINGS_MODULE'])
 
 
 def create_app(app_config):


### PR DESCRIPTION
Stop importing layman_settings dynamically
Pycharm autocomplete works for layman.settings
Remove LAYMAN_SETTINGS_MODULE environment variable


- ~~Tests~~
- ~~Layman Test Client~~
- [x] Changlelog
- [x] Documentation

