### PR TITLE
Metadata extent_equals uses no_area_bbox_padding of EPSG:4326

### DIFF
--- a/src/layman/common/metadata.py
+++ b/src/layman/common/metadata.py
@@ -12,7 +12,7 @@ def get_syncable_prop_names(publ_type):
     return prop_names
 
 
-def extent_equals(ext1, ext2):
+def extent_4326_equals(ext1, ext2):
     return bbox_util.are_similar(ext1, ext2, no_area_bbox_padding=crs_def.CRSDefinitions[crs_def.EPSG_4326].no_area_bbox_padding, limit=0.95)
 
 
@@ -65,7 +65,7 @@ PROPERTIES = {
     },
     'extent': {
         'upper_mp': '1',
-        'equals_fn': extent_equals,
+        'equals_fn': extent_4326_equals,
     },
     'wms_url': {
         'upper_mp': '1',

--- a/src/layman/common/metadata.py
+++ b/src/layman/common/metadata.py
@@ -13,7 +13,7 @@ def get_syncable_prop_names(publ_type):
 
 
 def extent_equals(ext1, ext2):
-    return bbox_util.are_similar(ext1, ext2, no_area_bbox_padding=crs_def.CRSDefinitions[crs_def.EPSG_3857].no_area_bbox_padding, limit=0.95)
+    return bbox_util.are_similar(ext1, ext2, no_area_bbox_padding=crs_def.CRSDefinitions[crs_def.EPSG_4326].no_area_bbox_padding, limit=0.95)
 
 
 PROPERTIES = {


### PR DESCRIPTION
instead the one of EPSG:3857. 

Part of issue #64 

- [x] Tests
- ~~Layman Test Client~~
- ~~Changlelog~~
- ~~Documentation~~
