### PR TITLE
Fix remark-validate-links for renamed remotes

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -2,7 +2,9 @@
   "settings": {
   },
   "plugins": {
-    "validate-links": null,
+    "validate-links": {
+      "repository": "git@github.com:layermanager/layman.git"
+    },
     "lint-no-dead-urls": {
       "skipLocalhost": true,
       "skipUrlPatterns": [


### PR DESCRIPTION
Part of issue #

- ~~Tests~~
- ~~Layman Test Client~~
- ~~Changelog~~
- ~~Documentation~~

Optionally
- Add dependency to doc/dependencies.md
