### PR TITLE
Username and password for external db can contain quoted characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
   - owslib 0.27.2 -> 0.28.1
 - [#833](https://github.com/LayerManager/layman/issues/833) Make Timgen WMS requests more robust (handle WML errors, delayed retry, add timestamp to each request).
 - [#815](https://github.com/LayerManager/layman/issues/815) Propagate [`LAYMAN_PROXY_SERVER_NAME`](doc/env-settings.md#LAYMAN_PROXY_SERVER_NAME) value to GeoServer environment variable [GEOSERVER_CSRF_WHITELIST](https://docs.geoserver.org/latest/en/user/security/webadmin/csrf.html).
+- [#847](https://github.com/LayerManager/layman/issues/847) Fix publishing external table layers with `@` in the username or the password.
 
 ## v1.20.1
  2023-04-11

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -40,11 +40,11 @@ class TableUri:
 
     @property
     def username(self):
-        return self._db_uri.username if self._db_uri else None
+        return parse.unquote(self._db_uri.username) if self._db_uri else None
 
     @property
     def password(self):
-        return self._db_uri.password if self._db_uri else None
+        return parse.unquote(self._db_uri.password) if self._db_uri else None
 
 
 PG_URI_STR = str()

--- a/tests/dynamic_data/publications/layer_external_db/edge_db_username_and_password.py
+++ b/tests/dynamic_data/publications/layer_external_db/edge_db_username_and_password.py
@@ -1,0 +1,86 @@
+from urllib.parse import quote
+from psycopg2 import sql
+import pytest
+
+from db import util as db_util
+from layman import settings
+from test_tools import process_client, external_db
+from tests import EnumTestTypes, Publication
+from tests.asserts.final.publication import util as assert_util
+from tests.dynamic_data import base_test, base_test_classes
+
+USERNAME = 'external@#$%^&*_db_user'
+PASSWORD = 'pass@#$%^&*word'
+FILE_PATH = 'sample/layman.layer/small_layer.geojson'
+SCHEMA = 'public'
+TABLE = 'edge_username_password'
+
+URI_STR = f'''postgresql://{quote(USERNAME)}:{quote(PASSWORD)}@{settings.LAYMAN_PG_HOST}:{settings.LAYMAN_PG_PORT}/{external_db.EXTERNAL_DB_NAME}'''
+
+pytest_generate_tests = base_test.pytest_generate_tests
+
+
+TEST_CASES = {
+    'edge_username_password',
+}
+
+
+@pytest.mark.usefixtures('ensure_external_db')
+class TestEdge(base_test.TestSingleRestPublication):
+
+    workspace = 'edge_db_username_and_password_workspace'
+
+    publication_type = process_client.LAYER_TYPE
+
+    rest_parametrization = []
+
+    test_cases = [base_test.TestCaseType(
+        key=key,
+        type=EnumTestTypes.MANDATORY,
+        rest_args={
+            'external_table_uri': f"{URI_STR}"
+                                  f"?schema={quote(SCHEMA)}"
+                                  f"&table={quote(TABLE)}"
+                                  f"&geo_column={quote(settings.OGR_DEFAULT_GEOMETRY_COLUMN)}",
+        },
+    ) for key in TEST_CASES]
+
+    external_tables_to_create = [
+        base_test_classes.ExternalTableDef(
+            file_path=FILE_PATH,
+            db_schema=SCHEMA,
+            db_table=TABLE,
+        ),
+    ]
+
+    def test_layer(self, layer: Publication, rest_method, rest_args, ):
+        """Parametrized using pytest_generate_tests"""
+        conn_cur = db_util.get_connection_cursor(external_db.URI_STR)
+        statement = sql.SQL(f"""
+        DO
+        $$BEGIN
+        IF ((SELECT count(*) FROM pg_roles WHERE rolname = {{username_value}}) > 0) THEN
+            REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM {{username}};
+            REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM {{username}};
+            REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM {{username}};
+            REVOKE ALL PRIVILEGES ON DATABASE {external_db.EXTERNAL_DB_NAME} FROM {{username}};
+        END IF;
+        END$$;
+        DROP USER IF EXISTS {{username}};
+        CREATE USER {{username}} WITH PASSWORD {{password}};
+        GRANT CONNECT ON DATABASE {external_db.EXTERNAL_DB_NAME} TO {{username}};
+        GRANT SELECT ON {{schema}}.{{table}} TO {{username}};
+        """).format(
+            username=sql.Identifier(USERNAME),
+            username_value=sql.Literal(USERNAME),
+            password=sql.Literal(PASSWORD),
+            schema=sql.Identifier(SCHEMA),
+            table=sql.Identifier(TABLE),
+        )
+        db_util.run_statement(statement, conn_cur=conn_cur)
+
+        # publish layer from external DB table
+        rest_method(layer, args=rest_args)
+
+        # general checks
+        assert_util.is_publication_valid_and_complete(layer)


### PR DESCRIPTION
Part of issue #847

- [x] Tests
- ~~Layman Test Client (including docker image at docker hub)~~
- [x] Changelog
- ~~Documentation~~
