### PR TITLE
Enable to `host.docker.internal` as alias for localhost for external table URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [#815](https://github.com/LayerManager/layman/issues/815) Propagate [`LAYMAN_PROXY_SERVER_NAME`](doc/env-settings.md#LAYMAN_PROXY_SERVER_NAME) value to GeoServer environment variable [GEOSERVER_CSRF_WHITELIST](https://docs.geoserver.org/latest/en/user/security/webadmin/csrf.html).
 - [#847](https://github.com/LayerManager/layman/issues/847) Fix publishing external table layers with `@` in the username or the password.
 - [#764](https://github.com/LayerManager/layman/issues/764), [#860](https://github.com/LayerManager/layman/issues/860) Layman accepts QML styles with labels without symbology and with point clustering.
+- [#857](https://github.com/LayerManager/layman/issues/857) Endpoints [POST Workspace Layers](doc/rest.md#post-workspace-layers) and [PATCH Workspace Layer](doc/rest.md#patch-workspace-layer) accepts `host.docker.internal` in `external_table_uri` parameter to reach `localhost` of host server.
 
 ## v1.20.1
  2023-04-11

--- a/doc/rest.md
+++ b/doc/rest.md
@@ -162,6 +162,7 @@ Body parameters:
    - [connection URI](https://www.postgresql.org/docs/15/libpq-connect.html#id-1.7.3.8.3.6) is required, usual format is `postgresql://<username>:<password>@<host>:<port>/<dbname>?schema=<schema_name>&table=<table_name>&geo_column=<geo_column_name>`
      - `host` part and query parameters `schema` and `table` are mandatory
      - URI scheme is required to be `postgresql`
+     - `host.docker.internal` can be used to reach `localhost` of host server
    - if `geo_column` is not specified, first geometry column of the table by alphabetic order is used
    - published table is required to have one-column primary key
    - names of schema, table and all columns of the table are required to match regular expression `^[a-zA-Z_][a-zA-Z_0-9]*$`

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -14,6 +14,7 @@ services:
       env_file:
          - .env
       extra_hosts:
+         - "host.docker.internal:host-gateway"
          - ${EXTRA_HOST1}
          - ${EXTRA_HOST2}
       volumes:
@@ -40,6 +41,7 @@ services:
         - C_FORCE_ROOT=true
         - LAYMAN_SKIP_REDIS_LOADING=true
       extra_hosts:
+         - "host.docker.internal:host-gateway"
          - ${EXTRA_HOST1}
          - ${EXTRA_HOST2}
       volumes:

--- a/docker-compose.deps.demo.yml
+++ b/docker-compose.deps.demo.yml
@@ -18,6 +18,8 @@ services:
       build:
         context: deps/qgis/docker
         dockerfile: Dockerfile
+      extra_hosts:
+         - "host.docker.internal:host-gateway"
       volumes:
         - ./deps/qgis/data:/qgis/data:ro
       restart: on-failure
@@ -30,6 +32,8 @@ services:
 
    geoserver:
       image: docker.osgeo.org/geoserver:2.21.2
+      extra_hosts:
+         - "host.docker.internal:host-gateway"
       volumes:
         - ./deps/geoserver/data:/opt/geoserver_data/
       restart: on-failure


### PR DESCRIPTION
Part of issue #859

- ~~Tests~~
- ~~Layman Test Client (including docker image at docker hub)~~
- [x] Changelog
- [x] Documentation

Optionally
- Add dependency to doc/dependencies.md
- Push docker image(s) to docker hub
