### PR TITLE
800 Document that time is always 00:00:00 for timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - [#847](https://github.com/LayerManager/layman/issues/847) Fix publishing external table layers with `@` in the username or the password.
 - [#764](https://github.com/LayerManager/layman/issues/764), [#860](https://github.com/LayerManager/layman/issues/860) Layman accepts QML styles with labels without symbology and with point clustering.
 - [#857](https://github.com/LayerManager/layman/issues/857) Endpoints [POST Workspace Layers](doc/rest.md#post-workspace-layers) and [PATCH Workspace Layer](doc/rest.md#patch-workspace-layer) accepts `host.docker.internal` in `external_table_uri` parameter to reach `localhost` of host server.
+- Document that temporal part of timeseries datetime dimension extracted by [`time_regex` parameter](doc/rest.md#post-workspace-layers) is cut off, so the smallest possible unit of datetime dimension is one day.
 
 ## v1.20.1
  2023-04-11

--- a/doc/models.md
+++ b/doc/models.md
@@ -34,6 +34,7 @@
 ## Timeseries
 - Timeseries is [layer](#layer) created from set of raster data files (GeoTIFF, JPEG2000, PNG or JPEG).
 - Each file represents one time instant, more files may represent the same time instant.
+- The smallest possible supported temporal unit is one day (see [#875](https://github.com/LayerManager/layman/issues/875)).
 - Information about time representation is passed through [time_regex](rest.md#post-workspace-layers) parameter.
   
 ## Map

--- a/doc/models.md
+++ b/doc/models.md
@@ -32,7 +32,7 @@
   - one metadata record per WMS&WFS layer
 
 ## Timeseries
-- Timeseries is [layer](#layer) created from set of raster data files (GeoJSON, ShapeFile, GeoTIFF, JPEG2000, PNG or JPEG).
+- Timeseries is [layer](#layer) created from set of raster data files (GeoTIFF, JPEG2000, PNG or JPEG).
 - Each file represents one time instant, more files may represent the same time instant.
 - Information about time representation is passed through [time_regex](rest.md#post-workspace-layers) parameter.
   

--- a/doc/rest.md
+++ b/doc/rest.md
@@ -217,6 +217,7 @@ Body parameters:
   - regular expression pattern used for extracting the time information from [timeseries](models.md#timeseries) raster file names. The pattern
     - either has no matching group and matches ISO 8601 [year](https://en.wikipedia.org/wiki/ISO_8601#Years), [date](https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates), or [datetime](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) patterns, e.g. `[0-9]{8}` or `[0-9]{8}T[0-9]{6}Z`
     - or has one or more matching groups that concatenated together matches ISO 8601 year, date, or datetime patterns, e.g. `^some_prefix_([0-9]{8})_some_postfix.*$` or , e.g. `some_prefix_([0-9]{8})_some_separator_(T[0-9]{6}Z)_some_postfix`
+  - although time pattern is accepted in time_regex, the temporal part is later cut off, so the smallest recognizable temporal unit is one day (see [#875](https://github.com/LayerManager/layman/issues/875))
   - latin diacritic is removed from the regex and spaces are replaced with underscores to be consistent with slugifying of timeseries filenames
   - error is raised if any of main data file names do not match *time_regex* value
 - *time_regex_format*, string, e.g. yyyyddMM
@@ -286,7 +287,9 @@ JSON object with following structure:
   - *time*, available only for time-series layers
     - **units**: String. Code of time format. Always `ISO8601`.
     - **values**: List of strings. Time instants available for layer written in ISO 8601 format.
+      - time part of the value is always `00:00:00.000Z` (see [#875](https://github.com/LayerManager/layman/issues/875))
     - **default**: Time. Default time instant.
+      - time part of the value is always `00:00:00Z` (see [#875](https://github.com/LayerManager/layman/issues/875))
     - **regex**: Slugified regular expression used to extract time instants from file names. Originally sent in `time_regex` parameter.
     - **regex_format**: Slugified format of `regex` result date and time. Originally sent in `time_regex_format` parameter.
   - *status*: Status information about GeoServer import and availability of WMS layer. No status object means the source is available. Usual state values are

--- a/tests/dynamic_data/publications/layer_timeseries/timeseries_test.py
+++ b/tests/dynamic_data/publications/layer_timeseries/timeseries_test.py
@@ -288,11 +288,11 @@ LAYERS = {
                 'native_bounding_box': [543100.0, 5573500.0, 552100.0, 5579500.0],
                 'image_mosaic': True,
                 'wms': {
-                    'time': {'default': '2022-03-16T00:00:00Z',
+                    'time': {'default': '2022-03-16T00:00:00Z',  # https://github.com/LayerManager/layman/issues/875
                              'units': 'ISO8601',
                              'regex': "^.*([0-9]{4}_[0-9]{2}_[0-9]{2}at[0-9]{2}-[0-9]{2}).*$",
                              'regex_format': "yyyy_dd_MM'at'HH-mm",
-                             'values': ['2022-03-16T00:00:00.000Z']},
+                             'values': ['2022-03-16T00:00:00.000Z']},  # https://github.com/LayerManager/layman/issues/875
                 },
             },
             'publ_type_detail': ('raster', 'sld'),


### PR DESCRIPTION
Part of issue #800 

- ~~Tests~~
- ~~Layman Test Client (including docker image at docker hub)~~
- [x] Changelog
- [x] Documentation
