### PR TITLE
868 Metadata property operates_on is read from DB

### DIFF
--- a/src/layman/map/micka/csw.py
+++ b/src/layman/map/micka/csw.py
@@ -128,16 +128,16 @@ def map_to_operates_on(workspace, mapname, operates_on_muuids_filter=None, edito
         layer_workspace = internal_layer['workspace']
         layername = internal_layer['name']
         layer_muuid = get_metadata_uuid(internal_layer['uuid'])
+        context = {'keys': ['title']}
         if operates_on_muuids_filter is not None:
             if layer_muuid not in operates_on_muuids_filter:
                 continue
-            layer_wms_info = get_publication_info(layer_workspace, LAYER_TYPE, layername, context={'keys': ['wms', ], })
         else:
-            layer_wms_info = get_publication_info(layer_workspace, LAYER_TYPE, layername, context={'keys': ['wfs', ],
-                                                                                                   'actor_name': editor, })
-            if not (layer_muuid and layer_wms_info):
-                continue
-        layer_title = layer_wms_info['title']
+            context['actor_name'] = editor
+        publ_info = get_publication_info(layer_workspace, LAYER_TYPE, layername, context=context)
+        if not (layer_muuid and publ_info):
+            continue
+        layer_title = publ_info['title']
         layer_csw_url = f"{csw_url}?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetRecordById&OUTPUTSCHEMA=http://www.isotc211.org/2005/gmd&ID={layer_muuid}#_{layer_muuid}"
         operates_on.append({
             'xlink:title': layer_title,

--- a/src/layman/map/micka/csw.py
+++ b/src/layman/map/micka/csw.py
@@ -108,7 +108,7 @@ def csw_insert(workspace, mapname, actor_name):
 
 def map_json_to_operates_on(map_json, operates_on_muuids_filter=None, editor=None):
     # Either caller know muuids or wants filter by editor, never both at the same time
-    assert not operates_on_muuids_filter or not editor
+    assert operates_on_muuids_filter is None or editor is None
     unquote_urls(map_json)
     gs_url = get_gs_proxy_base_url()
     gs_url = gs_url if gs_url.endswith('/') else f"{gs_url}/"

--- a/src/layman/map/micka/csw.py
+++ b/src/layman/map/micka/csw.py
@@ -117,8 +117,8 @@ def map_layers_to_operates_on_layers(map_layers):
 
 
 def map_to_operates_on(workspace, mapname, operates_on_muuids_filter=None, editor=None):
-    # Either caller know muuids or wants filter by editor, never both at the same time
-    assert operates_on_muuids_filter is None or editor is None
+    # Either caller know muuids or wants filter by editor, never both at the same time, at least one must be used
+    assert (operates_on_muuids_filter is None) != (editor is None)
     publ_info = layman_util.get_publication_info(workspace, MAP_TYPE, mapname, context={'keys': ['map_layers']})
     operates_on_layers = map_layers_to_operates_on_layers(publ_info['_map_layers'])
 
@@ -146,7 +146,7 @@ def map_to_operates_on(workspace, mapname, operates_on_muuids_filter=None, edito
     return operates_on
 
 
-def get_template_path_and_values(workspace, mapname, http_method=None, actor_name=None):
+def get_template_path_and_values(workspace, mapname, *, http_method=None, actor_name):
     assert http_method in [common.REQUEST_METHOD_POST, common.REQUEST_METHOD_PATCH]
     uuid_file_path = get_publication_uuid_file(MAP_TYPE, workspace, mapname)
     publ_datetime = datetime.fromtimestamp(os.path.getmtime(uuid_file_path))

--- a/src/layman/map/rest_workspace_test.py
+++ b/src/layman/map/rest_workspace_test.py
@@ -726,7 +726,8 @@ def test_map_composed_from_local_layers(client):
 
     with app.app_context():
         # assert metadata file is the same as filled template except for UUID and dates
-        template_path, prop_values = csw.get_template_path_and_values(workspace, mapname, http_method='post')
+        template_path, prop_values = csw.get_template_path_and_values(workspace, mapname, http_method='post',
+                                                                      actor_name=settings.ANONYM_USER)
         xml_file_object = micka_common_util.fill_xml_template_as_pretty_file_object(template_path, prop_values,
                                                                                     csw.METADATA_PROPERTIES)
         expected_path = 'src/layman/map/rest_test_filled_template.xml'

--- a/src/layman/map/util.py
+++ b/src/layman/map/util.py
@@ -20,7 +20,7 @@ from layman.util import call_modules_fn, get_providers_from_source_names, get_in
 from . import get_map_sources, MAP_TYPE, get_map_type_def, get_map_info_keys
 from .filesystem import input_file
 from .micka import csw
-from .micka.csw import map_json_to_operates_on
+from .micka.csw import map_to_operates_on
 
 MAPNAME_PATTERN = PUBLICATION_NAME_PATTERN
 MAPNAME_MAX_LENGTH = PUBLICATION_MAX_LENGTH
@@ -299,11 +299,11 @@ def get_crs_from_json(map_json):
     return map_json['projection'].upper()
 
 
-def map_file_to_metadata_properties(map_json, operates_on_muuids_filter):
+def map_file_to_metadata_properties(workspace, mapname, map_json, operates_on_muuids_filter):
     result = {
         'title': map_json['title'],
         'abstract': map_json['abstract'],
-        'operates_on': map_json_to_operates_on(map_json, operates_on_muuids_filter=operates_on_muuids_filter),
+        'operates_on': map_to_operates_on(workspace, mapname, operates_on_muuids_filter=operates_on_muuids_filter),
         'extent': list(get_bbox_from_json(map_json)),
         'reference_system': [get_crs_from_json(map_json)],
     }
@@ -325,7 +325,7 @@ def get_metadata_comparison(workspace, mapname):
     if map_json:
         soap_operates_on = next(iter(partial_infos[csw].values()))['operates_on'] if partial_infos[csw] else []
         operates_on_muuids_filter = micka_util.operates_on_values_to_muuids(soap_operates_on)
-        layman_file_props = map_file_to_metadata_properties(map_json, operates_on_muuids_filter)
+        layman_file_props = map_file_to_metadata_properties(workspace, mapname, map_json, operates_on_muuids_filter)
         map_file_url = url_for('rest_workspace_map_file.get', mapname=mapname, workspace=workspace)
         all_props[map_file_url] = layman_file_props
 

--- a/src/layman/map/util.py
+++ b/src/layman/map/util.py
@@ -387,7 +387,7 @@ def get_layers_from_json(map_json):
                      re.escape(layman_settings.LAYMAN_GS_PATH) + \
                      r'(?:(?P<workspace>' + layman_util.WORKSPACE_NAME_ONLY_PATTERN + r')/)?' \
                      + r'(?:ows|wms|wfs).*$'
-    found_layers = set()
+    found_layers = []
     for layer_idx, map_layer in enumerate(map_json['layers']):
         class_name = map_layer.get('className', '').split('.')[-1]
         layer_url_getter = {
@@ -422,5 +422,7 @@ def get_layers_from_json(map_json):
             if not match:
                 continue
             layer_workspace = get_layman_workspace(layer_geoserver_workspace)
-            found_layers.add((layer_workspace, layername, layer_idx))
+            layer_def = (layer_workspace, layername, layer_idx)
+            if layer_def not in found_layers:
+                found_layers.append(layer_def)
     return found_layers

--- a/src/layman/map/util_test.py
+++ b/src/layman/map/util_test.py
@@ -3,31 +3,31 @@ from . import util as map_util
 
 
 @pytest.mark.parametrize('json_path, exp_result', [
-    pytest.param('sample/layman.map/internal_url.json', {
+    pytest.param('sample/layman.map/internal_url.json', [
         ('testuser1', 'hranice', 1),
         ('testuser1', 'mista', 2),
         ('testuser1', 'hranice', 3),
-    }, id='two_internal_wms_layers,one_internal_wfs_layer'),
-    pytest.param('sample/layman.map/internal_url_two_wms_layers_in_one.json', {
+    ], id='two_internal_wms_layers,one_internal_wfs_layer'),
+    pytest.param('sample/layman.map/internal_url_two_wms_layers_in_one.json', [
         ('testuser1', 'hranice', 0),
         ('testuser1', 'mista', 0),
-    }, id='two_internal_wms_layers_in_one'),
-    pytest.param('sample/layman.map/internal_url_wms_workspace_in_layername.json', {
+    ], id='two_internal_wms_layers_in_one'),
+    pytest.param('sample/layman.map/internal_url_wms_workspace_in_layername.json', [
         ('testuser1', 'hranice', 0),
         ('testuser2', 'mista', 0),
-    }, id='two_internal_wms_layers_in_one,workspace_in_layername'),
-    pytest.param('sample/layman.map/internal_url_wms_layers_with_client_proxy.json', {
+    ], id='two_internal_wms_layers_in_one,workspace_in_layername'),
+    pytest.param('sample/layman.map/internal_url_wms_layers_with_client_proxy.json', [
         ('testuser1', 'hranice', 0),
         ('testuser1', 'mista', 1),
-    }, id='two_internal_wms_layers_with_client_proxy'),
-    pytest.param('sample/layman.map/internal_url_wms_layer_in_wfs_workspace.json', {
+    ], id='two_internal_wms_layers_with_client_proxy'),
+    pytest.param('sample/layman.map/internal_url_wms_layer_in_wfs_workspace.json', [
         ('testuser1', 'hranice', 0),
-    }, id='one_internal_wms_layer_in_wfs_workspace'),
-    pytest.param('sample/layman.map/internal_url_wfs_workspace_in_layername.json', {
+    ], id='one_internal_wms_layer_in_wfs_workspace'),
+    pytest.param('sample/layman.map/internal_url_wfs_workspace_in_layername.json', [
         ('testuser1', 'hranice', 0),
-    }, id='one_internal_wfs_layer,workspace_in_layername'),
-    pytest.param('sample/layman.map/internal_external_edge_cases.json', set(), id='empty_edge_cases'),
-    pytest.param('sample/layman.map/full.json', set(), id='external_layers_only'),
+    ], id='one_internal_wfs_layer,workspace_in_layername'),
+    pytest.param('sample/layman.map/internal_external_edge_cases.json', [], id='empty_edge_cases'),
+    pytest.param('sample/layman.map/full.json', [], id='external_layers_only'),
 ])
 def test_get_layers_from_json(json_path, exp_result):
     with open(json_path, 'r', encoding="utf-8") as map_file:

--- a/src/layman/upgrade/upgrade_v1_22.py
+++ b/src/layman/upgrade/upgrade_v1_22.py
@@ -95,7 +95,7 @@ def insert_map_layer_relations():
             map_layers = map_util.get_layers_from_json(map_json)
         except FileNotFoundError:
             logger.warning(f'File not found for map {workspace}.{map_name}, map file path {map_file_path}')
-            map_layers = set()
+            map_layers = []
         for layer_workspace, layer_name, layer_index in map_layers:
             insert_query = f'''
             insert into {DB_SCHEMA}.map_layer(id_map, layer_workspace, layer_name, layer_index) values (%s, %s, %s, %s);

--- a/tests/asserts/final/publication/internal.py
+++ b/tests/asserts/final/publication/internal.py
@@ -459,5 +459,5 @@ def consistent_internal_map_layers(workspace, publ_type, name):
         pub_info = layman_util.get_publication_info(workspace, publ_type, name, {'keys': ['map_layers']})
         map_json = map_input_file.get_map_json(workspace, name)
     layers_from_file = map_util.get_layers_from_json(map_json)
-    layers_from_info = {(ml['workspace'], ml['name'], ml['index']) for ml in pub_info['_map_layers']}
+    layers_from_info = [(ml['workspace'], ml['name'], ml['index']) for ml in pub_info['_map_layers']]
     assert layers_from_file == layers_from_info

--- a/tests/asserts/final/publication/metadata.py
+++ b/tests/asserts/final/publication/metadata.py
@@ -53,7 +53,8 @@ def expected_values_in_micka_metadata(workspace, publ_type, name, expected_value
                                             )
 
 
-def correct_values_in_metadata(workspace, publ_type, name, http_method):
+def correct_values_in_metadata(workspace, publ_type, name, http_method, *, exp_values=None):
+    exp_values = exp_values or {}
     md_props = {
         process_client.LAYER_TYPE: LAYER_METADATA_PROPERTIES,
         process_client.MAP_TYPE: MAP_METADATA_PROPERTIES,
@@ -74,4 +75,6 @@ def correct_values_in_metadata(workspace, publ_type, name, http_method):
     exp_metadata = {key: value for key, value in md_values.items() if key in md_props}
     if publ_type == process_client.LAYER_TYPE:
         exp_metadata['reference_system'] = [int(crs.split(':')[1]) for crs in exp_metadata['reference_system']]
+    for key, value in exp_values.items():
+        assert exp_metadata[key] == value, f"Template value differ from expected value, key={key}"
     expected_values_in_micka_metadata(workspace, publ_type, name, exp_metadata)

--- a/tests/dynamic_data/publications/layer_timeseries/timeseries_test.py
+++ b/tests/dynamic_data/publications/layer_timeseries/timeseries_test.py
@@ -369,7 +369,7 @@ class TestLayer(base_test.TestSingleRestPublication):
             else:
                 raise NotImplementedError(f"Unknown rest_method: {rest_method}")
 
-            asserts_publ.metadata.correct_values_in_layer_metadata(layer.workspace, layer.type, layer.name, http_method=http_method)
+            asserts_publ.metadata.correct_values_in_metadata(layer.workspace, layer.type, layer.name, http_method=http_method)
 
             process_client.patch_workspace_layer(layer.workspace,
                                                  layer.name,

--- a/tests/dynamic_data/publications/map_layer_relation/map_layer_relation.py
+++ b/tests/dynamic_data/publications/map_layer_relation/map_layer_relation.py
@@ -1,8 +1,10 @@
 import os
 from layman import app
+from layman.common import REQUEST_METHOD_POST
 from layman.util import get_publication_info
 from test_tools import process_client
 from tests import EnumTestTypes, Publication
+from tests.asserts.final import publication as asserts_publ
 from tests.asserts.final.publication import util as assert_util
 from tests.dynamic_data import base_test, base_test_classes
 
@@ -94,6 +96,8 @@ class TestPublication(base_test.TestSingleRestPublication):
         rest_method(map, args=rest_args)
         if rest_method == self.post_publication:  # pylint: disable=W0143
             assert_util.is_publication_valid_and_complete(map)
+            asserts_publ.metadata.correct_values_in_metadata(map.workspace, map.type, map.name,
+                                                             http_method=REQUEST_METHOD_POST)
 
         with app.app_context():
             publ_info = get_publication_info(map.workspace, map.type, map.name,

--- a/tests/dynamic_data/publications/map_layer_relation/map_layer_relation.py
+++ b/tests/dynamic_data/publications/map_layer_relation/map_layer_relation.py
@@ -92,7 +92,7 @@ class TestPublication(base_test.TestSingleRestPublication):
         self.assert_exp_map_layers(publ_info, params['exp_map_layers_before_rest_method'])
 
         rest_method(map, args=rest_args)
-        if params['rest_method'] == base_test_classes.RestMethodAll.POST:
+        if rest_method == self.post_publication:  # pylint: disable=W0143
             assert_util.is_publication_valid_and_complete(map)
 
         with app.app_context():


### PR DESCRIPTION
Part of issue #868 

- [x] Tests
  - layman.map.rest_workspace_test.test_map_composed_from_local_layers
  - static_data
    - (COMMON_WORKSPACE, MAP_TYPE, 'post_internal_layer')
    - (OWNER, MAP_TYPE, 'post_unauthorized_layer'),
    - (OWNER2, LAYER_TYPE, 'post_private_sld2')
- ~~Layman Test Client (including docker image at docker hub)~~
- ~~Changelog~~
- ~~Documentation~~